### PR TITLE
[FIX] invalid `dash` in multiple returns doc's

### DIFF
--- a/generator/generate.py
+++ b/generator/generate.py
@@ -622,7 +622,7 @@ class CdpCommand:
         elif len(self.returns) > 1:
             doc += '\n'
             doc += ':returns: A tuple with the following items:\n\n'
-            ret_docs = '\n'.join(f'{i}. **{r.name}** – {r.generate_doc()}' for i, r
+            ret_docs = '\n'.join(f'{i}. **{r.name}** - {r.generate_doc()}' for i, r
                 in enumerate(self.returns))
             doc += indent(ret_docs, 4)
         if doc:


### PR DESCRIPTION
Weird bug this one but easy fix,  When I run `python generator/generate.py`   the resultant cpd modules fail to load.
The error given is  generated cpd files have a 
![image](https://user-images.githubusercontent.com/11743864/75867420-73785900-5e6b-11ea-9f37-6edee0ab4a95.png)

a git diff of the generated `cpd/page.py` shows all docs for returns with multiple items as follows
![image](https://user-images.githubusercontent.com/11743864/75867776-fa2d3600-5e6b-11ea-8613-3cc173246191.png)


Looking at `generator/generate.py`  with a binary compare `cmp -b ` show's the following
![image](https://user-images.githubusercontent.com/11743864/75867640-c8b46a80-5e6b-11ea-8c7c-c4a577f85a49.png)

The fix of correcting the `dash` character to ascii 55, seems to fix this.

By the way I have pulled the browser_protocol.json for chromium 82 and this generated well and is working on the latest Chrome Dev v82, Nice one !!!!, May be worth creating a branch of the repo with the latest Chrome Dev release. 

