### PR TITLE
Unicode character change.

### DIFF
--- a/generator/generate.py
+++ b/generator/generate.py
@@ -622,7 +622,7 @@ class CdpCommand:
         elif len(self.returns) > 1:
             doc += '\n'
             doc += ':returns: A tuple with the following items:\n\n'
-            ret_docs = '\n'.join(f'{i}. **{r.name}** – {r.generate_doc()}' for i, r
+            ret_docs = '\n'.join(f'{i}. **{r.name}** - {r.generate_doc()}' for i, r
                 in enumerate(self.returns))
             doc += indent(ret_docs, 4)
         if doc:


### PR DESCRIPTION
Using the character "–" raises unicode errors. I propose swapping it out for the almost identical "-".