### PR TITLE
crash bug due to missing ENUM

### DIFF
--- a/cdp/page.py
+++ b/cdp/page.py
@@ -617,6 +617,7 @@ class ClientNavigationReason(enum.Enum):
     META_TAG_REFRESH = "metaTagRefresh"
     PAGE_BLOCK_INTERSTITIAL = "pageBlockInterstitial"
     RELOAD = "reload"
+    ANCHOR_CLICK = "anchorClick"
 
     def to_json(self) -> str:
         return self.value


### PR DESCRIPTION
When listening to events, if a frame is navigated by user clicking on a simple link, any attacked event watcher workers will crash with this exception:
ValueError: 'anchorClick' is not a valid ClientNavigationReason
Tested on latest edge and chrome (chromium 113).
Probably because the CDP has newer events that were not hardcoded in this ENUM. There may be more, I only added the one that was causing crash!